### PR TITLE
:db/identity values were being dropped by `datascript-schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.2 - 2017-11-01
+### Fixed
+- The `datascript-schema` function was incorrectly dropping the `:db/identity` values from maps.
+
 ## [0.7.1] - 2017-10-31
 ### Fixed
 - Compatibility with Clojure 1.9.0-beta4 by using `decimal?` instead of `bigdec?`.

--- a/build.boot
+++ b/build.boot
@@ -1,5 +1,5 @@
 (def project 'provisdom/spectomic)
-(def version "0.7.1")
+(def version "0.7.2")
 
 (set-env! :resource-paths #{"src"}
           :source-paths #{"test"}

--- a/src/provisdom/spectomic/core.clj
+++ b/src/provisdom/spectomic/core.clj
@@ -123,8 +123,8 @@
      (reduce (fn [ds-schema schema]
                (assoc ds-schema
                  (:db/ident schema)
-                 ;; only include :db/valueType when it is a ref.
-                 (let [schema (select-keys schema [:db/cardinality :db/valueType])]
+                 (let [schema (select-keys schema [:db/cardinality :db/unique :db/valueType])]
+                   ;; only include :db/valueType when it is a ref.
                    (if (= :db.type/ref (:db/valueType schema))
                      schema
                      (dissoc schema :db/valueType)))))

--- a/test/provisdom/spectomic/core_test.clj
+++ b/test/provisdom/spectomic/core_test.clj
@@ -132,7 +132,11 @@
                  :db/valueType   :db.type/ref}}
     [::string ::int ::inst ::double ::float ::uuid
      ::bigdec ::bigint ::uri ::keyword ::bytes ::int-coll
-     ::map]))
+     ::map]
+    {::int {:db/cardinality :db.cardinality/one
+            :db/unique :db.unique/identity}}
+    [[::int {:db/index true
+             :db/unique :db.unique/identity}]]))
 
 (deftest datomic-schema-valueType-test
   (are [schema specs] (= schema (spectomic/datomic-schema specs))


### PR DESCRIPTION
This PR also updates the tests to catch the error that it fixes. It bumps the project’s version to 0.7.2.